### PR TITLE
Add index method for guilds, only returns the guild the user owns or …

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,0 +1,22 @@
+.dashboard-guild-list {
+  background-size: cover;
+  background-position: center;
+  height: 180px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: white;
+  font-size: 24px;
+  font-weight: bold;
+  text-shadow: 2px 2px 3px rgba(0,0,0,1);
+  border-radius: 5px;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  transition: 0.3s;
+  margin: 20px;
+
+  &:hover {
+    transform: scale(1.1);
+    text-decoration: none;
+    color: white;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -5,3 +5,4 @@
 @import "banner";
 @import "show_navbar";
 @import "guild_memberships";
+@import "card";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,10 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  def after_sign_in_path_for(*)
+    guilds_path
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[first_name last_name nickname])
     devise_parameter_sanitizer.permit(:account_update, keys: %i[first_name last_name nickname about])

--- a/app/views/guilds/index.html.erb
+++ b/app/views/guilds/index.html.erb
@@ -1,3 +1,5 @@
-<% @guilds.each do |guild| %>
-  <p><%= guild.name %></p>
-<% end %>
+<div class="container">
+  <% @guilds.each do |guild| %>
+    <%= link_to guild.name, guild_path(guild), class: "dashboard-guild-list", style: "background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3)), url(https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/breakfast.jpg)"  %>
+  <% end %>
+</div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,19 +7,17 @@
     <span class="navbar-toggler-icon"></span>
   </button>
 
+  <% if user_signed_in? %>
+    <h2 class="text-center align-middle m-2">Welcome <%= current_user.first_name || current_user.nickname || current_user.email %></h2>
+  <% end %>
 
   <div class="collapse navbar-collapse" id="navbarSupportedContent">
     <ul class="navbar-nav mr-auto">
       <% if user_signed_in? %>
-        <li class="nav-item active">
-          <%= link_to "Home", "#", class: "nav-link" %>
-        </li>
-        <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
-        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+            <p><%= current_user.email %></p>
             <%= link_to "Action", "#", class: "dropdown-item" %>
             <%= link_to "Another action", "#", class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>


### PR DESCRIPTION
…is a part of.

Index action for guilds now returns all the guilds that the user owns AND all the guilds they are part of.
Added a method to the Application Controller to redirect the user to /guilds after logging in, instead of the landing page.
Added temporary cards in the index page for the guilds.
Added a "Welcome <user>" to the Navbar if the user is logged in. Added logic to display the users first name if it is present, nickname if no first name is present and email if none of the other two are present.
Added some basic styling, all subject to change.