### PR TITLE
Add manage action/route/view for guild

### DIFF
--- a/app/controllers/guilds_controller.rb
+++ b/app/controllers/guilds_controller.rb
@@ -1,5 +1,5 @@
 class GuildsController < ApplicationController
-  before_action :set_guild, only: %i[show edit update destroy]
+  before_action :set_guild, only: %i[show edit update destroy manage]
   def index
     @guilds = policy_scope(Guild)
   end
@@ -35,6 +35,8 @@ class GuildsController < ApplicationController
       render :edit
     end
   end
+
+  def manage; end
 
   private
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     false
   end
 
+  def manage?
+    false
+  end
+
   class Scope
     attr_reader :user, :scope
 

--- a/app/policies/guild_policy.rb
+++ b/app/policies/guild_policy.rb
@@ -16,4 +16,8 @@ class GuildPolicy < ApplicationPolicy
   def update?
     record.user == user || record.guildmemberships.where(user: user, admin: true).present?
   end
+
+  def manage?
+    record.user == user || record.guildmemberships.where(user: user, admin: true).present?
+  end
 end

--- a/app/views/guilds/manage.html.erb
+++ b/app/views/guilds/manage.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <h1>This is the manage page for <%= @guild.name %></h1>
+  <% if policy(@guild).edit? %>
+    <%= link_to "Edit guild details", edit_guild_path(@guild) %>
+  <% end %>
+  <p>Things to add: Ability to make another user an admin, ban users, invite users, delete the guild(only if there are no guild members, deny deletion even for owner if there are guild members associated with this guild)</p>
+</div>

--- a/app/views/guilds/show.html.erb
+++ b/app/views/guilds/show.html.erb
@@ -14,6 +14,11 @@
       <li class="nav-item">
         <a class="nav-link" id="video-posts-tab" data-toggle="tab" href="#video-posts" role="tab" aria-controls="video-posts" aria-selected="false" style="border: none;">Videos</a>
       </li>
+      <li class="nav-item">
+        <% if policy(@guild).manage? %>
+          <%= link_to "Manage Guild", manage_guild_path(@guild) %>
+        <% end %>
+      </li>
     </ul>
   </div>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <div class="navbar navbar-expand-sm navbar-light navbar-lewagon">
-  <%= link_to "#", class: "navbar-brand" do %>
+  <%= link_to guilds_path, class: "navbar-brand" do %>
     <%= image_tag "https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/logo.png" %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   resources :guilds do
     resources :milestones
     resources :posts, only: [:new, :create, :edit, :update, :destroy]
+
+    member do
+      get "manage"
+    end
   end
 
 end


### PR DESCRIPTION
Added the Manage page for guild admins. 

Manage Guild is ONLY visible if you are authorized to see it. 

Checks whether the user is the owner of the guild, or set as an admin for the guild. 

Position of this option on the show page is temporary. Probably need to put links that redirect to a new page to a different place, but this works for testing purposes without having to type /manage in the URL all the time.

Still needs nice styling.