### PR TITLE
Add destroy guild action

### DIFF
--- a/app/controllers/guilds_controller.rb
+++ b/app/controllers/guilds_controller.rb
@@ -38,6 +38,18 @@ class GuildsController < ApplicationController
 
   def manage; end
 
+  def destroy
+    if @guild.guildmemberships.empty?
+      if @guild.destroy
+        flash[:notice] = "#{@guild.name} has successfully been deleted"
+        redirect_to guilds_path
+      end
+    else
+      flash[:alert] = "Can not delete a guild that has members. Please remove all the members and try again."
+      render :manage
+    end
+  end
+
   private
 
   def set_guild

--- a/app/policies/guild_policy.rb
+++ b/app/policies/guild_policy.rb
@@ -14,10 +14,20 @@ class GuildPolicy < ApplicationPolicy
   end
 
   def update?
-    record.user == user || record.guildmemberships.where(user: user, admin: true).present?
+    check_admin?
   end
 
   def manage?
+    check_admin?
+  end
+
+  def destroy?
+    check_admin?
+  end
+
+  private
+
+  def check_admin?
     record.user == user || record.guildmemberships.where(user: user, admin: true).present?
   end
 end

--- a/app/views/guilds/manage.html.erb
+++ b/app/views/guilds/manage.html.erb
@@ -1,7 +1,6 @@
 <div class="container">
   <h1>This is the manage page for <%= @guild.name %></h1>
-  <% if policy(@guild).edit? %>
-    <%= link_to "Edit guild details", edit_guild_path(@guild) %>
-  <% end %>
-  <p>Things to add: Ability to make another user an admin, ban users, invite users, delete the guild(only if there are no guild members, deny deletion even for owner if there are guild members associated with this guild)</p>
+  <p><%= link_to "Edit guild details", edit_guild_path(@guild) %></p>
+  <p><%= link_to "Delete the guild", guild_path(@guild), method: :delete, data: {confirm: "Are you sure you wish to delete the guild?"}, error: "Something went wrong. Please make sure the guild has no members before trying again. If this issue persists, please contact us for help." %></p>
+  <p>Things to add: Ability to make another user an admin, ban users, invite users</p>
 </div>

--- a/app/views/guilds/manage.html.erb
+++ b/app/views/guilds/manage.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <h1>This is the manage page for <%= @guild.name %></h1>
   <p><%= link_to "Edit guild details", edit_guild_path(@guild) %></p>
-  <p><%= link_to "Delete the guild", guild_path(@guild), method: :delete, data: {confirm: "Are you sure you wish to delete the guild?"}, error: "Something went wrong. Please make sure the guild has no members before trying again. If this issue persists, please contact us for help." %></p>
+  <p><%= link_to "Delete the guild", guild_path(@guild), method: :delete, data: {confirm: "Are you sure you wish to delete the guild?"} %></p>
   <p>Things to add: Ability to make another user an admin, ban users, invite users</p>
 </div>


### PR DESCRIPTION
Added the ability to destroy a guild.

Link is displayed in the Manage page.

When you try to destroy a guild, it checks if there are any guild members still in the guild. If there are, it won't delete, but if the guild is empty, then you can delete it.