### PR TITLE
Added ability to ban members and make members admins

### DIFF
--- a/app/controllers/guildmemberships_controller.rb
+++ b/app/controllers/guildmemberships_controller.rb
@@ -1,4 +1,8 @@
 class GuildmembershipsController < ApplicationController
+  def index
+    @memberships = policy_scope(Guildmembership).where(guild: params[:guild_id])
+  end
+  
   def create
     @user = User.find(params[:user])
     @guild = Guild.find(params[:guild_id])
@@ -12,5 +16,17 @@ class GuildmembershipsController < ApplicationController
       flash[:alert] = "Can not invite. User has already been invited to the guild"
     end
     redirect_to manage_guild_path(@guild)
+  end
+
+  def update
+    @membership = Guildmembership.find(params[:id])
+    authorize @membership
+    if @membership.update(admin: params[:admin], banned: params[:banned])
+      flash[:notice] = "#{@membership.user.first_name} successfully updated!"
+      redirect_to manage_guild_path(@membership.guild)
+    else
+      flash[:alert] = "Something went wrong, please try again. If this issue persists, please contact us for help."
+      render :index
+    end
   end
 end

--- a/app/policies/guild_policy.rb
+++ b/app/policies/guild_policy.rb
@@ -10,7 +10,7 @@ class GuildPolicy < ApplicationPolicy
   end
 
   def show?
-    record.user == user || record.guildmemberships.where(user: user).present?
+    record.user == user || record.guildmemberships.where(user: user, banned: false).present?
   end
 
   def update?

--- a/app/policies/guildmembership_policy.rb
+++ b/app/policies/guildmembership_policy.rb
@@ -8,4 +8,8 @@ class GuildmembershipPolicy < ApplicationPolicy
   def create?
     record.guild.user == user
   end
+
+  def update?
+    record.guild.user == user || record.guild.guildmemberships.where(user: user, admin: true).present?
+  end
 end

--- a/app/views/guildmemberships/index.html.erb
+++ b/app/views/guildmemberships/index.html.erb
@@ -1,0 +1,18 @@
+<div class="container">
+  <h1>These are current guild members:</h1>
+  <% @memberships.each do |membership| %>
+    <div class="card-user">
+      <img class="avatar-large" src="https://res.cloudinary.com/dx6rtf9wl/image/upload/v1614345377/john_aj1jop.jpg" />
+      <div class="card-user-infos">
+        <h2><%= membership.user.first_name unless nil? %> <%= membership.user.last_name unless nil? %> </h2>
+        <h3><%= "Nickname: #{membership.user.nickname}" unless membership.user.nickname.nil? %></h3>
+      </div>
+      <% if membership.guild.user == current_user %> 
+        <%= link_to "Add as Admin" , guild_guildmembership_path(id: membership, admin: true, banned: false), method: :patch, class: "btn btn-success invite-btn" unless membership.admin?%>
+        <%= link_to "Remove as Admin" , guild_guildmembership_path(id: membership, admin: false, banned: false), method: :patch, class: "btn btn-success invite-btn" unless !membership.admin?%>
+      <% end %>
+      <%= link_to "Ban" , guild_guildmembership_path(id: membership, admin: false, banned: true), method: :patch, class: "btn btn-success invite-btn" unless membership.banned?%>
+      <%= link_to "Unban" , guild_guildmembership_path(id: membership, admin: false, banned: false), method: :patch, class: "btn btn-success invite-btn" unless !membership.banned?%>
+    </div>
+  <% end %>
+</div>

--- a/app/views/guilds/manage.html.erb
+++ b/app/views/guilds/manage.html.erb
@@ -12,5 +12,5 @@
       <% end %>
     </div>
   </div>
-  <p>Things to add: Ability to make another user an admin, ban users, invite users</p>
+  <p><%= link_to "Manage access", guild_guildmemberships_path(@guild), class: "btn invite-btn" %></p>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :guilds do
     resources :milestones
     resources :posts, only: [:new, :create, :edit, :update, :destroy]
-    resources :guildmemberships, only: [:create]
+    resources :guildmemberships, only: [:create, :index, :update]
     resources :users, only: [:index]
     member do
       get "manage"


### PR DESCRIPTION
Added the ability to ban people and add them as admins.

I got stuck with the code for quite a while but finally managed it I think, although it is a bit weird and might need another look later.

Added a Manage Access button to Manage Guild page, allowing you to ban users, unban users, make them admins or remove their admin status. The owner of the guild does not appear in that list, because you can't ban or remove the admin status of the owner of the guild.

If the user is already an admin, you can remove their status. If the user is banned, you can unban them.
If you are not the owner of the guild but you ARE an admin, you can ban yourself (might need to remove this later).

Only the owner of the guild can assign other people as admins.