### PR TITLE
Only the assigned person can mark the task as complete now.

### DIFF
--- a/app/controllers/milestones_controller.rb
+++ b/app/controllers/milestones_controller.rb
@@ -19,7 +19,7 @@ class MilestonesController < ApplicationController
     authorize @milestone
     if @milestone.save
       flash[:notice] = "Milestone successfully created!"
-      redirect_to guild_milestones_path
+      redirect_to guild_milestone_path(@milestone.guild, @milestone)
     else
       flash[:alert] = "Something went wrong, please try again. If this issue persists, please contact us for help."
       render :new

--- a/app/views/guilds/show.html.erb
+++ b/app/views/guilds/show.html.erb
@@ -111,10 +111,18 @@
         </div>
         <div class="guild-members">
           <ul>
-            <li><%= @guild.user.full_name %></li>
+            <% if @guild.user.photo.attached? %>
+              <li><%= cl_image_tag(@guild.user.photo.key, crop: :fill, style:"height: 40px; width: 40px;", class: "avatar dropdown-toggle border border-dark", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false) %> <%= @guild.user.full_name %></li>
+            <% else %>
+              <li><%= image_tag "https://res.cloudinary.com/dx6rtf9wl/image/upload/v1615222704/user_xyjx1w.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %> <%= @guild.user.full_name %></li>
+            <% end %>
             <% @guild.guildmemberships.each do |guildmembership| %>
               <% if guildmembership.status == "approved" %>
-                <li><%= guildmembership.user.full_name %></li>
+                <% if guildmembership.user.photo.attached? %>
+                  <li><%= cl_image_tag(guildmembership.user.photo.key, crop: :fill, style:"height: 40px; width: 40px;", class: "avatar dropdown-toggle border border-dark", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false) %> <%= guildmembership.user.full_name %></li>
+                <% else %>
+                  <li><%= image_tag "https://res.cloudinary.com/dx6rtf9wl/image/upload/v1615222704/user_xyjx1w.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %> <%= guildmembership.user.full_name %></li>
+                <% end %>
               <% end %>
             <% end %>
           </ul>

--- a/app/views/milestones/show.html.erb
+++ b/app/views/milestones/show.html.erb
@@ -11,7 +11,7 @@
                 <%= f.association :user, :as => :select, :collection => @guild.members, :label_method => :email, :value_method => :id %>
                 <%= f.submit %>
               <% end %>
-            <%= link_to "back", guild_milestone_path(@milestone) %>
+            <%= link_to "Back", guild_milestone_path(@milestone) %>
           </div>
       </div>
     </div>
@@ -25,11 +25,13 @@
       <h6><i class="far fa-gem"></i> <%= @milestone.reward %></h6>
     </div>
     <div class="milestone-box2">
-      <div class= "milestone-btns">
-        <%= link_to "Destroy", guild_milestone_path(@milestone), method: :delete, data: {confirm: "Are you sure you wish to delete it?"}, class: "btn-milestone"%>
-        <%= link_to "Completed", guild_milestone_path(@guild, @milestone, completed: true), method: :patch, class: "btn-milestone" %>
-        <%= link_to "Activate", guild_milestone_path(@guild, @milestone, completed: false), method: :patch, class: "btn-milestone" %>
-      </div>
+      <% if @milestone.guild.user == current_user || @milestone.guild.guildmemberships.where(user: current_user, admin: true).present? %>
+        <div class= "milestone-btns">
+          <%= link_to "Destroy", guild_milestone_path(@milestone), method: :delete, data: {confirm: "Are you sure you wish to delete it?"}, class: "btn-milestone"%>
+          <%= link_to "Completed", guild_milestone_path(@guild, @milestone, completed: true), method: :patch, class: "btn-milestone" %>
+          <%= link_to "Activate", guild_milestone_path(@guild, @milestone, completed: false), method: :patch, class: "btn-milestone" %>
+        </div>
+      <% end %>
       <div style="display: flex; justify-content: center;">
         <% if @milestone.completed %>
           <%="Status : #{@milestone.title} is completed"%>
@@ -73,9 +75,7 @@
             <% end %>
           </div>
           <div class="task-status-btn">
-            <% if task.completed %>
-              <%= link_to "Start task", milestone_task_path(@milestone, task, task: {completed: false}), method: :patch, class: "btn-milestone" %>
-            <% else %>
+            <% if !task.completed && (task.user == current_user || task.milestone.guild.user == current_user) %>
               <%= link_to "Mark as complete", milestone_task_path(@milestone, task, task: {completed: true}), method: :patch, class: "btn-milestone" %>
             <% end %>
           </div>


### PR DESCRIPTION
Added profile pictures to the Guild Members list.
Fixed the task authorization. Only the person who the task is assigned to can now mark it complete. Currently removed the "Start Task" when the milestone is re-activated. Probably need to fix it in the backend, so when you re-activate a milestone it sets all tasks associated with the milestone to false, but not sure we'll have time for it. For the purposes of the demo I think we just need to mark as complete.