### PR TITLE
Made pictures tab render properly, changed avatar and icon position

### DIFF
--- a/app/views/guilds/show.html.erb
+++ b/app/views/guilds/show.html.erb
@@ -22,9 +22,6 @@
             <a class="show-nav-link" id="picture-posts-tab" data-toggle="tab" href="#picture-posts" role="tab" aria-controls="picture-posts" aria-selected="false" style="border: none;"><i class="fas fa-camera"></i>Pictures</a>
           </li>
           <li class="show-nav-item">
-            <a class="show-nav-link" id="video-posts-tab" data-toggle="tab" href="#video-posts" role="tab" aria-controls="video-posts" aria-selected="false" style="border: none;"><i class="fas fa-video"></i>Videos</a>
-          </li>
-          <li class="show-nav-item">
             <%= link_to guild_milestones_path(@guild)  do %>
             <i class="fas fa-shapes"></i>Active Milestones
             <% end %>
@@ -52,28 +49,24 @@
             </div>
             <% @guild.posts.order(created_at: :desc).each do |post| %>
               <div class="post">
-                <div class="avatar-picture ml-3">
-                  <% if post.user.photo.attached? %>
-                    <%= cl_image_tag(post.user.photo.key, crop: :fill, gravitate: :face, height: 40, width: 40, class: "avatar avatar-lg border border-dark") %>
-                  <% else %>
-                   <img class="avatar avatar-lg border border-dark" src="https://res.cloudinary.com/dx6rtf9wl/image/upload/v1615222704/user_xyjx1w.png" alt="" style="border-radius: 50%;" />
-                  <% end %>
-
-                </div>
                 <div class="post-content mt-3 ml-4">
-                  <p style="font-size: 15px; font-weight: bold; color: #0f295f; margin: 0;"><%= post.user.full_name %> <span style="font-size: 10px; font-weight: lighter; color: rgba(0,0,0,0.5);"><%= post.created_at.strftime("%d/%m/%Y - %H:%M") %></span></p>
-                  <p style="margin-bottom: 0px; margin-left: 30px;">
+                    <% if post.user.photo.attached? %>
+                      <p style="font-size: 15px; font-weight: bold; color: #0f295f; margin: 0;"><%= cl_image_tag(post.user.photo.key, crop: :fill, gravitate: :face, height: 40, width: 40, class: "avatar avatar-lg border border-dark") %> <span style="margin-left: 5px;"><%= post.user.full_name %></span> <span style="font-size: 10px; font-weight: lighter; color: rgba(0,0,0,0.5);"><%= post.created_at.strftime("%d/%m/%Y - %H:%M") %></span></p>
+                    <% else %>
+                    <img class="avatar avatar-lg border border-dark" src="https://res.cloudinary.com/dx6rtf9wl/image/upload/v1615222704/user_xyjx1w.png" alt="" style="border-radius: 50%;" />
+                    <% end %>
+                  <p style="margin-bottom: 0px; margin-left: 30px; margin-top: 10px;">
                     <%= post.content %>
                   </p>
                   <div class="post-edit">
                     <div>
                       <% if post.user == current_user %>
-                        <%= link_to edit_guild_post_path(@guild, post), style: "font-size: 12px;" do%>
+                        <%= link_to edit_guild_post_path(@guild, post), style: "font-size: 12px; position: absolute; right: 30px; bottom: 10px;" do%>
                         <i class="fas fa-edit"></i>
                         <% end %>
                       <% end %>
                       <% if policy(post).destroy? %>
-                        <%= link_to guild_post_path(@guild, post), method: :delete, data: {confirm: "Are you sure you wish to delete it?"}, style: "font-size: 12px;" do %>
+                        <%= link_to guild_post_path(@guild, post), method: :delete, data: {confirm: "Are you sure you wish to delete it?"}, style: "font-size: 12px; position: absolute; right: 10px; bottom: 10px;" do %>
                         <i class="fas fa-trash-alt"></i>
                         <% end %>
                       <% end %>
@@ -85,11 +78,32 @@
           </div>
 
           <div class="tab-pane fade" id="picture-posts" role="tabpanel" aria-labelledby="picture-posts-tab">
-            <% @posts_with_pictures.each do |post| %>
-            <div class="post" style="display: flex; align-items: center; justify-content: left; min-width: 45vw; max-width:45vw;">
-              <div class="post-content">
-                <%= post.content %>
-              </div>
+            <% @posts_with_pictures.sort_by(&:created_at).reverse.each do |post| %>
+              <div class="post">
+                <div class="post-content mt-3 ml-4">
+                    <% if post.user.photo.attached? %>
+                      <p style="font-size: 15px; font-weight: bold; color: #0f295f; margin: 0;"><%= cl_image_tag(post.user.photo.key, crop: :fill, gravitate: :face, height: 40, width: 40, class: "avatar avatar-lg border border-dark") %> <span style="margin-left: 5px;"><%= post.user.full_name %></span> <span style="font-size: 10px; font-weight: lighter; color: rgba(0,0,0,0.5);"><%= post.created_at.strftime("%d/%m/%Y - %H:%M") %></span> </p>
+                    <% else %>
+                    <img class="avatar avatar-lg border border-dark" src="https://res.cloudinary.com/dx6rtf9wl/image/upload/v1615222704/user_xyjx1w.png" alt="" style="border-radius: 50%;" />
+                    <% end %>
+                  <p style="margin-bottom: 0px; margin-left: 30px; margin-top: 10px;">
+                    <%= post.content %>
+                  </p>
+                  <div class="post-edit">
+                    <div>
+                      <% if post.user == current_user %>
+                        <%= link_to edit_guild_post_path(@guild, post), style: "font-size: 12px; position: absolute; right: 30px; bottom: 10px;" do%>
+                        <i class="fas fa-edit"></i>
+                        <% end %>
+                      <% end %>
+                      <% if policy(post).destroy? %>
+                        <%= link_to guild_post_path(@guild, post), method: :delete, data: {confirm: "Are you sure you wish to delete it?"}, style: "font-size: 12px; position: absolute; right: 10px; bottom: 10px;" do %>
+                        <i class="fas fa-trash-alt"></i>
+                        <% end %>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
               </div>
             <% end %>
           </div>


### PR DESCRIPTION
Pictures tab now works properly. Now only shows the posts that have pictures in them in the correct order (recent ones at the top).
Made user avatars stick to the top regardless of how long the post is.
Positioned the edit and delete icons properly so they are always on the bottom right of the post.